### PR TITLE
add type as input to mem.split()

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -36,7 +36,7 @@ fn shellLoop(stdin: std.fs.File.Reader, stdout: std.fs.File.Writer) !void {
 
         // Split by a single space. The returned SplitIterator must be var because
         // it has mutable internal state.
-        var tokens = std.mem.split(input_str, " ");
+        var tokens = std.mem.split(u8, input_str, " ");
 
         // Copy each string "token" into the storage array and save a pointer to it.
         var i: usize = 0;
@@ -66,7 +66,6 @@ fn shellLoop(stdin: std.fs.File.Reader, stdout: std.fs.File.Writer) !void {
             // If we make it this far, the exec() call has failed!
             try stdout.print("ERROR: {}\n", .{result});
             return;
-
         } else { // We are the parent.
 
             // waitpid() waits for the child with specified PID and returns


### PR DESCRIPTION
Hey there! Thanks for the repository - super useful resource.

Tried running the project and realized it didn't build because `mem.split()` seems to require a `type` as the first input now.

The newline change seems to be `zig fmt` magic, since I have format on save enabled.